### PR TITLE
Warrior Grapple toss 4 tiles distance with no stun.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -256,9 +256,9 @@
 /datum/action/xeno_action/activable/toss/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/X = owner
 	var/atom/movable/target = owner.pulling
-	var/fling_distance = 3
+	var/fling_distance = 4
 	var/stagger_slow_stacks = 3
-	var/stun_duration = 1 SECONDS
+	var/stun_duration = 0 SECONDS
 	var/big_mob_message
 
 	X.face_atom(A)


### PR DESCRIPTION
## About The Pull Request

Changes the distance for grapple toss to 4 tiles and no longer stuns.

## Why It's Good For The Game

Warrior is no longer is the fisher machine it was, but grapple toss should have some use instead of a 3 tiles displacement. With 4 tiles it would have more utility but will give the marine a chance with the no stuns.

## Changelog
:cl:
Balance: Grapple toss distance from 3 tiles to 4 with 0 seconds of stun.
/:cl: